### PR TITLE
adding bias in pallas attention

### DIFF
--- a/jax_triton/pallas/ops/attention.py
+++ b/jax_triton/pallas/ops/attention.py
@@ -352,8 +352,10 @@ def _mha_backward(sm_scale: float, causal: bool, block_q: int, block_k: int,
     has_bias = (bias is not None)
 
     if has_bias:
+      input_output_alias = 9
       bias_block_spec = pl.BlockSpec(lambda j, k: (j, k, 0, 0), (None, None, seq_len, seq_len))
     else:
+      input_output_alias = 8
       bias_block_spec = None
 
     grid = (batch_size, num_heads)
@@ -386,7 +388,7 @@ def _mha_backward(sm_scale: float, causal: bool, block_q: int, block_k: int,
         interpret=interpret,
         num_warps=num_warps,
         num_stages=1,
-        input_output_aliases={9: 0})(q, k, v, bias, out, do_scaled, l, m, delta, dq)
+        input_output_aliases={input_output_alias: 0})(q, k, v, bias, out, do_scaled, l, m, delta, dq)
   else:
     raise ValueError(f"Invalid backward pass implementation: {backward_pass_impl}")
   return dq.astype(q.dtype), dk, dv, None

--- a/jax_triton/pallas/ops/attention.py
+++ b/jax_triton/pallas/ops/attention.py
@@ -386,7 +386,7 @@ def _mha_backward(sm_scale: float, causal: bool, block_q: int, block_k: int,
         interpret=interpret,
         num_warps=num_warps,
         num_stages=1,
-        input_output_aliases={8: 0})(q, k, v, bias, out, do_scaled, l, m, delta, dq)
+        input_output_aliases={9: 0})(q, k, v, bias, out, do_scaled, l, m, delta, dq)
   else:
     raise ValueError(f"Invalid backward pass implementation: {backward_pass_impl}")
   return dq.astype(q.dtype), dk, dv, None

--- a/jax_triton/pallas/ops/attention.py
+++ b/jax_triton/pallas/ops/attention.py
@@ -69,9 +69,6 @@ def mha_forward_kernel(
       span_q = start_q * block_q + jnp.arange(block_q)
       span_k = start_k * block_k + jnp.arange(block_k)
       qk = jnp.where(span_q[:, None] >= span_k[None, :], qk, float('-inf'))
-    # Bring closer to XLA:GPU numerics.
-    qk = qk.astype(q_ref.dtype)
-    qk = qk.astype(jnp.float32)
     m_curr = jnp.maximum(jnp.max(qk, axis=1), m_prev)
     l_prev *= jnp.exp(m_prev - m_curr)
     p = jnp.exp(qk - m_curr[:, None])
@@ -280,8 +277,6 @@ def mha_backward_kernel(
       dv, dk = carry
       q = pl.load(q_ref, (pl.ds(start_q * block_q, block_q), slice(None)))
       qk = pl.dot(q, k.T)
-      qk = qk.astype(q_ref.dtype)
-      qk = qk.astype(jnp.float32)
       if sm_scale != 1.0:
         qk *= sm_scale
 

--- a/jax_triton/pallas/ops/attention.py
+++ b/jax_triton/pallas/ops/attention.py
@@ -62,10 +62,8 @@ def mha_forward_kernel(
     # Load bias.
     # bias in the shape of [block_q, block_k]
     if has_bias:
-        bias = pl.load(bias_ref, (pl.dslice(start_q * block_q, block_q), pl.dslice(start_k * block_k, block_k)))
-        qk = qk.astype(bias.dtype)
+        bias = pl.load(bias_ref, (pl.dslice(start_q * block_q, block_q), pl.dslice(start_k * block_k, block_k))).astype(jnp.float32)
         qk += bias
-        qk = qk.astype(jnp.float32)
 
     if causal:
       span_q = start_q * block_q + jnp.arange(block_q)
@@ -288,10 +286,8 @@ def mha_backward_kernel(
         qk *= sm_scale
 
       if has_bias:
-          bias = pl.load(bias_ref, (pl.dslice(start_q * block_q, block_q), pl.dslice(start_k * block_k, block_k)))
-          qk = qk.astype(bias.dtype)
+          bias = pl.load(bias_ref, (pl.dslice(start_q * block_q, block_q), pl.dslice(start_k * block_k, block_k))).astype(jnp.float32)
           qk += bias
-          qk = qk.astype(jnp.float32)
 
       if causal:
         span_q = start_q * block_q + jnp.arange(block_q)

--- a/jax_triton/pallas/ops/attention.py
+++ b/jax_triton/pallas/ops/attention.py
@@ -45,8 +45,6 @@ def mha_forward_kernel(
   # read, compute, and write all in 2d chunks. 1 element ~= 1 CUDA thread index.
   # q tile has shape [block_q, block_d], block_d == head_dim.
   q = pl.load(q_ref, (pl.dslice(start_q * block_q, block_q), pl.dslice(None)))
-
-
   # In FlashAttention algorithm 1 there are 2 loops: slow over tiles of kv (size
   # (Bc == block_k here), and fast over blocks of q (size Br == block_q here).
   # Here we only loop over blocks of kv to process entire seq_len, the loop over
@@ -140,7 +138,6 @@ def mha(q, k, v,
   if has_bias:
     bias_block_spec = pl.BlockSpec(lambda _, j, k: (j, k, 0, 0), (None, None, seq_len, seq_len))
   else:
-    # bias_block_spec = pl.BlockSpec(lambda _, __, ___: (), ())
     bias_block_spec = None
 
   return pl.pallas_call(

--- a/jax_triton/pallas/ops/attention.py
+++ b/jax_triton/pallas/ops/attention.py
@@ -63,7 +63,9 @@ def mha_forward_kernel(
     # bias in the shape of [block_q, block_k]
     if has_bias:
         bias = pl.load(bias_ref, (pl.dslice(start_q * block_q, block_q), pl.dslice(start_k * block_k, block_k)))
+        qk = qk.astype(bias.dtype)
         qk += bias
+        qk = qk.astype(jnp.float32)
 
     if causal:
       span_q = start_q * block_q + jnp.arange(block_q)

--- a/jax_triton/pallas/ops/attention.py
+++ b/jax_triton/pallas/ops/attention.py
@@ -289,7 +289,10 @@ def mha_backward_kernel(
 
       if has_bias:
           bias = pl.load(bias_ref, (pl.dslice(start_q * block_q, block_q), pl.dslice(start_k * block_k, block_k)))
+          qk = qk.astype(bias.dtype)
           qk += bias
+          qk = qk.astype(jnp.float32)
+
       if causal:
         span_q = start_q * block_q + jnp.arange(block_q)
         qk = jnp.where(span_q[:, None] >= span_k[None, :], qk, float('-inf'))

--- a/jax_triton/pallas/ops/attention.py
+++ b/jax_triton/pallas/ops/attention.py
@@ -352,7 +352,7 @@ def _mha_backward(sm_scale: float, causal: bool, block_q: int, block_k: int,
     has_bias = (bias is not None)
 
     if has_bias:
-      bias_block_spec = pl.BlockSpec(lambda _, j, k: (j, k, 0, 0), (None, None, seq_len, seq_len))
+      bias_block_spec = pl.BlockSpec(lambda j, k: (j, k, 0, 0), (None, None, seq_len, seq_len))
     else:
       bias_block_spec = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.8,<3.11"
 dependencies = [
   "absl-py>=1.4.0",
   "jax @ git+https://github.com/google/jax@d2d30bc4fdd721632af5d0974588cfd71d10b54b",
-  "triton @ git+https://github.com/openai/triton@acf1ede5bfd0729bb99e848fb8edace0a24da8d4#subdirectory=python",
+  "triton @ git+https://github.com/openai/triton@55eb32dff93f8d63993cfe33c8e66167ca50652f#subdirectory=python",
 ]
 
 [build-system]

--- a/tests/pallas_test.py
+++ b/tests/pallas_test.py
@@ -1465,8 +1465,8 @@ class FusedAttentionTest(parameterized.TestCase):
     def f_ref(q, k, v, bias):
       return attention.mha_reference(q, k, v, bias, causal=causal, has_bias=True).sum()
 
-    dq, dk, dv = jax.grad(f, argnums=(0, 1, 2))(q, k, v)
-    dq_ref, dk_ref, dv_ref = jax.grad(f_ref, argnums=(0, 1, 2))(q, k, v)
+    dq, dk, dv = jax.grad(f, argnums=(0, 1, 2))(q, k, v, bias)
+    dq_ref, dk_ref, dv_ref = jax.grad(f_ref, argnums=(0, 1, 2))(q, k, v, bias)
     np.testing.assert_allclose(dq, dq_ref, atol=0.1)
     np.testing.assert_allclose(dk, dk_ref, atol=0.08)
     np.testing.assert_allclose(dv, dv_ref, atol=0.05)

--- a/tests/pallas_test.py
+++ b/tests/pallas_test.py
@@ -1444,8 +1444,6 @@ class FusedAttentionTest(parameterized.TestCase):
           (1, 384, 1, 32, True),
           (2, 384, 2, 32, True),
           (2, 2048, 32, 64, False),
-          (2, 2048, 32, 64, False),
-          (4, 1024, 72, 64, False),
           (4, 1024, 72, 64, False),
       ]
   ])

--- a/tests/pallas_test.py
+++ b/tests/pallas_test.py
@@ -1406,8 +1406,8 @@ class FusedAttentionTest(parameterized.TestCase):
       for batch_size, seq_len, num_heads, head_dim, causal in [
           (1, 384, 1, 32, False),
           (2, 384, 2, 32, False),
-          # TODO(b/283035396): (1, 384, 1, 32, True),
-          # TODO(b/283035396): (2, 384, 2, 32, True),
+          (1, 384, 1, 32, True),
+          (2, 384, 2, 32, True),
       ]
   ])
   def test_fused_attention_bwd(self, batch_size, seq_len, num_heads, head_dim,
@@ -1428,6 +1428,42 @@ class FusedAttentionTest(parameterized.TestCase):
 
     def f_ref(q, k, v):
       return attention.mha_reference(q, k, v, causal=causal).sum()
+
+    dq, dk, dv = jax.grad(f, argnums=(0, 1, 2))(q, k, v)
+    dq_ref, dk_ref, dv_ref = jax.grad(f_ref, argnums=(0, 1, 2))(q, k, v)
+    np.testing.assert_allclose(dq, dq_ref, atol=0.1)
+    np.testing.assert_allclose(dk, dk_ref, atol=0.08)
+    np.testing.assert_allclose(dv, dv_ref, atol=0.05)
+
+  @parameterized.named_parameters(*[
+      (f"{batch_size=}_{seq_len=}_{num_heads=}_{head_dim=}_{causal=}",
+       batch_size, seq_len, num_heads, head_dim, causal)
+      for batch_size, seq_len, num_heads, head_dim, causal in [
+          (1, 384, 1, 32, False),
+          (2, 384, 2, 32, False),
+          (1, 384, 1, 32, True),
+          (2, 384, 2, 32, True),
+      ]
+  ])
+  def test_fused_attention_bwd_bias(self, batch_size, seq_len, num_heads, head_dim,
+                               causal):
+    if jt.get_compute_capability(0) < 80:
+      raise unittest.SkipTest(
+          "Fused attention only works on GPUs with capability >= sm80")
+    k1, k2, k3, k4 = random.split(random.PRNGKey(0), 3)
+    q = random.normal(k1, (batch_size, seq_len, num_heads, head_dim),
+                      dtype=jnp.float16)
+    k = random.normal(k2, (batch_size, seq_len, num_heads, head_dim),
+                      dtype=jnp.float16)
+    v = random.normal(k3, (batch_size, seq_len, num_heads, head_dim),
+                      dtype=jnp.float16)
+    bias = random.normal(k4, (batch_size, num_heads, seq_len, seq_len), dtype=jnp.float16)
+
+    def f(q, k, v, bias):
+      return attention.mha(q, k, v, bias, causal=causal, num_stages=1).sum()
+
+    def f_ref(q, k, v, bias):
+      return attention.mha_reference(q, k, v, bias, causal=causal, has_bias=True).sum()
 
     dq, dk, dv = jax.grad(f, argnums=(0, 1, 2))(q, k, v)
     dq_ref, dk_ref, dv_ref = jax.grad(f_ref, argnums=(0, 1, 2))(q, k, v)

--- a/tests/pallas_test.py
+++ b/tests/pallas_test.py
@@ -1450,7 +1450,7 @@ class FusedAttentionTest(parameterized.TestCase):
     if jt.get_compute_capability(0) < 80:
       raise unittest.SkipTest(
           "Fused attention only works on GPUs with capability >= sm80")
-    k1, k2, k3, k4 = random.split(random.PRNGKey(0), 3)
+    k1, k2, k3, k4 = random.split(random.PRNGKey(0), 4)
     q = random.normal(k1, (batch_size, seq_len, num_heads, head_dim),
                       dtype=jnp.float16)
     k = random.normal(k2, (batch_size, seq_len, num_heads, head_dim),

--- a/tests/pallas_test.py
+++ b/tests/pallas_test.py
@@ -1443,6 +1443,10 @@ class FusedAttentionTest(parameterized.TestCase):
           (2, 384, 2, 32, False),
           (1, 384, 1, 32, True),
           (2, 384, 2, 32, True),
+          (2, 2048, 32, 64, False),
+          (2, 2048, 32, 64, False),
+          (4, 1024, 72, 64, False),
+          (4, 1024, 72, 64, False),
       ]
   ])
   def test_fused_attention_bwd_bias(self, batch_size, seq_len, num_heads, head_dim,

--- a/tests/pallas_test.py
+++ b/tests/pallas_test.py
@@ -1372,6 +1372,9 @@ class FusedAttentionTest(parameterized.TestCase):
           (1, 384, 8, 64, True, True),
           (2, 384, 8, 64, True, True),
           (2, 2048, 32, 64, False, False),
+          (2, 2048, 32, 64, False, True),
+          (4, 1024, 72, 64, False, False),
+          (4, 1024, 72, 64, False, True),
       ]
   ])
   def test_fused_attention_fwd_bias(self, batch_size, seq_len, num_heads, head_dim,


### PR DESCRIPTION
Current there's some precision issue with the bias. It's likely due to the type conversions. I tried various type conversion (or removing the conversions) and couldn't find a way to further narrow down the diff.

To reproduce the precision issue:

> pytest tests/ -k test_fused_attention_bwd_bias

An example failed case
> E           Mismatched elements: 524 / 18874368 (0.00278%)
> E           Max absolute difference: 0.25
> E           Max relative difference: inf
> E            x: array([[[[ 3.3945e+00, -7.5342e-01, -2.8496e+00, ...,  2.8359e+00,
> E                     -2.4258e+00, -7.9346e-01],
> E                    [ 1.0576e+00,  4.4043e-01,  3.8047e+00, ..., -2.8945e+00,...
> E            y: array([[[[ 3.4043e+00, -7.5391e-01, -2.8555e+00, ...,  2.8438e+00,
> E                     -2.4277e+00, -7.9492e-01],
> E                    [ 1.0566e+00,  4.3921e-01,  3.7988e+00, ..., -2.8887e+00,...